### PR TITLE
Remove extraneous fmt.Errorf call

### DIFF
--- a/cmd/use.go
+++ b/cmd/use.go
@@ -30,7 +30,6 @@ var useCmd = &cobra.Command{
 
 		err := os.Symlink(pathToBinary, symlinkPath)
 		if err != nil {
-			fmt.Errorf("%s", err)
 			return err
 		}
 


### PR DESCRIPTION
I think I used this for debugging at some point